### PR TITLE
Point package.json repo, bugs, homepage fields at new org page

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test mocha --check-leaks --globals __core-js_shared__,index"
   },
-  "repository": "github:zeke/jus",
+  "repository": "github:jus/jus",
   "website": "http://jus.js.org",
   "keywords": [
     "es6",
@@ -36,9 +36,9 @@
   "author": "zeke",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/zeke/jus/issues"
+    "url": "https://github.com/jus/jus/issues"
   },
-  "homepage": "https://github.com/zeke/jus#readme",
+  "homepage": "https://github.com/jus/jus#readme",
   "devDependencies": {
     "chai": "^3.4.1",
     "cross-env": "^2.0.0",


### PR DESCRIPTION
Changed the `repository`, `homepage`, and `bugs` fields in `package.json` to point to the [new org repo](https://github.com/jus/jus).