### PR TITLE
Support nested layouts

### DIFF
--- a/lib/files/layout.js
+++ b/lib/files/layout.js
@@ -2,6 +2,7 @@
 
 const fs              = require('fs')
 const path            = require('upath')
+const frontmatter     = require('html-frontmatter')
 const File            = require('../file')
 
 module.exports = class Layout extends File {
@@ -14,6 +15,7 @@ module.exports = class Layout extends File {
     this.squeezed = false
     this.setName()
     this.read()
+    this.getFrontmatter()
     this.squeezed = true
   }
 
@@ -31,6 +33,10 @@ module.exports = class Layout extends File {
       .replace(/layout/i, '')
       .replace(/^(-|_)+/, '')
       .replace(/(-|_)+$/, '')
+  }
+
+  getFrontmatter() {
+    Object.assign(this, frontmatter(this.input))
   }
 
   static test(filename) {

--- a/lib/files/page.js
+++ b/lib/files/page.js
@@ -79,6 +79,18 @@ module.exports = class Page extends File {
       || titlecase(this.path.name)
   }
 
+  // Return an array of ancestor layouts
+  extractLayouts (layouts, current) {
+    var result = []
+
+    while (current) {
+      result.push(current)
+      current = layouts[current.layout]
+    }
+
+    return result
+  }
+
   render(context, done) {
     var $ = this.$
     var ctx = Object.assign({page: this}, context)
@@ -97,8 +109,12 @@ module.exports = class Page extends File {
     // Convert DOM to HTML so it can be handlebarred
     output = $.html()
 
-    // Wrap layout around page
-    if (layout) output = layout.wrap(output)
+    // Wrap layout(s) around page
+    if (layout) {
+      this.extractLayouts(layouts, layout).forEach(layout => {
+        output = layout.wrap(output)
+      })
+    }
 
     // decode quotes in handlebars statements
     var mustaches = output.match(/{([^{}]*)}/g)

--- a/test/fixtures/layout-nested.html
+++ b/test/fixtures/layout-nested.html
@@ -1,0 +1,7 @@
+<!--
+layout: default
+-->
+
+<div id="nested-layout">
+  {{{body}}}
+</div>

--- a/test/fixtures/nested.md
+++ b/test/fixtures/nested.md
@@ -1,0 +1,5 @@
+<!--
+layout: nested
+-->
+
+I am wrapped in two layouts

--- a/test/jus.js
+++ b/test/jus.js
@@ -420,6 +420,17 @@ describe('jus', function () {
       })
     })
 
+    they('can be nested', function(done){
+      var page = pages['/nested.md']
+      expect(page).to.exist
+      page.render(context, function(err, output){
+        var $ = cheerio.load(output)
+        expect($('p').length).to.equal(1)
+        expect($('#default-layout').length).to.equal(1)
+        expect($('#nested-layout').length).to.equal(1)
+        done()
+      })
+    })
   })
 
   describe('stylesheets', function(){


### PR DESCRIPTION
This is a handy feature available in other handlebars implementations. Now, layouts may have other layouts as parents. To use the default layout, you must explicitly name 'default' as the layout in frontmatter.