### PR TITLE
Make 'path-exists' a dependency not a devDependency

### DIFF
--- a/lib/ignored.js
+++ b/lib/ignored.js
@@ -1,6 +1,5 @@
 const path      = require('upath')
 const fs        = require('fs')
-const exists    = require('path-exists').sync
 // const globs     = require('gitignore-globs')
 
 // A list of `anymatch` patterns for chokidar to ignore when juicing a directory


### PR DESCRIPTION
This fixes #59. `lib/ignored.js` calls the 'path-exists' module, so `jus` gave an error when I used it to build `jus.js.org` because `jus` - installed as a dependency of `jus.js.org` - did not install devDependencies. The unit tests for `jus` didn't catch this because when you run `npm install` for jus, it also installs devDepencencies. Yet you need the devDepencencies to run the tests... I don't know WHAT the best practice is to catch this kind of issue is in CI.