### PR TITLE
Keep marky-markdown and still support Node v4

### DIFF
--- a/lib/files/page.js
+++ b/lib/files/page.js
@@ -2,7 +2,12 @@
 
 const fs              = require('fs')
 const path            = require('upath')
+// TODO: Fix marky-markdown so it doesn't even try to require highlights by default.
+// Or fix highlights.
+// Or fix oniguruma.
+process.browser = true
 const marky           = require('marky-markdown')
+process.browser = undefined
 const cheerio         = require('cheerio')
 const frontmatter     = require('html-frontmatter')
 const handlebars      = require('handlebars')
@@ -40,7 +45,7 @@ module.exports = class Page extends File {
       this.$ = marky(this.input, {
         sanitize: false,            // allow script tags and stuff
         linkify: true,              // turn orphan URLs into hyperlinks
-        highlightSyntax: true,      // run highlights on fenced code blocks
+        highlightSyntax: false,     // run highlights on fenced code blocks (disabled because of Oniguruma issues)
         prefixHeadingIds: false,    // prevent DOM id collisions
       })
     } else {


### PR DESCRIPTION
Having become intimately familiar with the oniguruma dependency in `marky-markdown` while working on making `marky-markdown` browserify compatible, I just *happen* to know off the top of my head a hacky workaround.

**We would need to figure out an alternative code-highlighting solution.** (Or port oniguruma to JS and be done with the beast.)