### PR TITLE
Add handlebars-helpers

### DIFF
--- a/lib/files/page.js
+++ b/lib/files/page.js
@@ -11,10 +11,12 @@ const cheerio         = require('cheerio')
 const frontmatter     = require('html-frontmatter')
 const handlebars      = require('handlebars')
 const lobars          = require('lobars')
+const hbsHelpers      = require('handlebars-helpers')
 const titlecase       = require('inflection').titleize
 const File            = require('../file')
 
 handlebars.registerHelper(lobars)
+handlebars.registerHelper(hbsHelpers())
 
 module.exports = class Page extends File {
   constructor(filepath, sourceDir, targetDir) {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "fs-extra": "^0.26.3",
     "get-image-colors": "^1.5.0",
     "handlebars": "^4.0.5",
+    "handlebars-helpers": "^0.10.0",
     "html-frontmatter": "^1.6.0",
     "identicon": "^2.1.1",
     "image-size": "^0.5.0",

--- a/test/fixtures/other/mango.markdown
+++ b/test/fixtures/other/mango.markdown
@@ -1,0 +1,5 @@
+<!--
+  description: try me with lime and chile
+-->
+
+{{pascalcase page.description}}

--- a/test/jus.js
+++ b/test/jus.js
@@ -230,6 +230,19 @@ describe('jus', function () {
 
     })
 
+    describe('handlebars-helpers', function () {
+      test('pascalcase', function (done) {
+        var page = pages['/other/mango.markdown']
+
+        expect(page.description).to.include('try me with lime and chile')
+
+        page.render(context, function (err, output) {
+          expect(output).to.include('TryMeWithLimeAndChile')
+          done()
+        })
+      })
+    })
+
     describe('`src` attributes in the DOM', function() {
       var $input
       var $output


### PR DESCRIPTION
Refs #81 

One caveat here: handlebars doesn't seem to do any type of validations on the names of helpers. This means if you register a helper with the same name as a previously registered helper, it will overwrite the first.

I ran the intersection of the keys exported by lobars and handlebars-helpers, and found 17 duplicate helper names between the libraries:

- capitalize
- escape
- replace
- split
- trim
- truncate
- eq
- gt
- gte
- isArray
- isEmpty
- isMatch
- isObject
- isString
- lt
- lte
- startsWith

This means all of these helpers from lobars will be overridden by the ones exported from handlebars-helpers. I expect these all have the same exact behavior between the two libraries, but thought I should point this out. I thought about removing lobars entirely, but that library has 50 additional helpers that handlebars-helpers does not offer.